### PR TITLE
ZAP is no longer an OWASP project

### DIFF
--- a/current-version/2-Process/2-4-Operation/2-4-3-Pentest.md
+++ b/current-version/2-Process/2-4-Operation/2-4-3-Pentest.md
@@ -80,7 +80,7 @@ Lastly, after delivering the report and initiating the vulnerability management 
 
 There are several tools that can help while performing penetration test against applications. The most common are:
 - [BurpSuite](https://portswigger.net/burp) - A comprehensive software tool used for web application security testing. Key features include a proxy for intercepting and modifying web traffic, a scanner for automated vulnerability detection and tools for performing manual testing, such as repeater, intruder and so forth.
-- [OWASP Zed Attack Proxy (ZAP)](https://www.zaproxy.org) - An open-source web proxy similar that has features similar to BurpSuite's.
+- [Zed Attack Proxy (ZAP)](https://www.zaproxy.org) - An open-source web proxy similar that has features similar to BurpSuite's.
 - [Postman](https://www.postman.com/) - API testing tool that allows sending various HTTP requests, manipulating headers and automating tests. It helps identify vulnerabilities like authentication issues and data exposure, integrating with other security tools for comprehensive analysis.
 - [MobSF](https://github.com/MobSF/Mobile-Security-Framework-MobSF) - Automated, open-source tool for security testing and analyzing mobile applications, supporting both Android and iOS platforms.
 


### PR DESCRIPTION
Hopefully thisis the right file to change - redirected from https://github.com/OWASP/www-project-devsecops-guideline/pull/29